### PR TITLE
Bugfix: Use protocol relative URL for the video.js CDN

### DIFF
--- a/Classes/Controller/VideoplayerController.php
+++ b/Classes/Controller/VideoplayerController.php
@@ -232,8 +232,8 @@ class VideoplayerController extends ActionController {
 			$swf = '<script>videojs.options.flash.swf = "' . $folder . 'video-js-' . self::VIDEO_JS_VERSION . '/video-js.swf"</script>';
 
 			if (isset($this->settings['videoJsCdn']) && $this->settings['videoJsCdn']) {
-				$css = 'http://vjs.zencdn.net/' . self::VIDEO_JS_VERSION . '/video-js.css';
-				$javaScript = 'http://vjs.zencdn.net/' . self::VIDEO_JS_VERSION . '/video.js';
+				$css = '//vjs.zencdn.net/' . self::VIDEO_JS_VERSION . '/video-js.css';
+				$javaScript = '//vjs.zencdn.net/' . self::VIDEO_JS_VERSION . '/video.js';
 				$swf = FALSE;
 			}
 


### PR DESCRIPTION
When using https and the "CDN" option you'll get a "Mixed Content" error because of the hardcoded protocol in the URLs that inject the css/js files into the header.
