### PR TITLE
[FEATURE] Make start time of video configurable

### DIFF
--- a/Classes/Domain/Model/Video.php
+++ b/Classes/Domain/Model/Video.php
@@ -142,6 +142,13 @@ class Video extends AbstractEntity
     protected $loopvideo;
 
     /**
+     * Start time of the video (in s)
+     *
+     * @var integer
+     */
+    protected $videoStarttime;
+
+    /**
      *
      * @var boolean
      */
@@ -371,6 +378,22 @@ class Video extends AbstractEntity
     public function setAutoplayvideo($autoplayvideo)
     {
         $this->autoplayvideo = $autoplayvideo;
+    }
+
+    /**
+     * @return int
+     */
+    public function getVideoStarttime()
+    {
+        return $this->videoStarttime;
+    }
+
+    /**
+     * @param int $videoStarttime
+     */
+    public function setVideoStarttime($videoStarttime)
+    {
+        $this->videoStarttime = $videoStarttime;
     }
 
     /**

--- a/Configuration/TCA/tx_html5videoplayer_domain_model_video.php
+++ b/Configuration/TCA/tx_html5videoplayer_domain_model_video.php
@@ -342,6 +342,14 @@ $tca = array(
 				'type' => 'check',
 			)
 		),
+		'video_starttime'        => array(
+			'exclude' => 1,
+			'label'   => 'LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:tx_html5videoplayer_domain_model_video.video_starttime',
+			'config'  => array(
+				'type' => 'input',
+                'eval' => 'int'
+			)
+		),
 		'controlsvideo'    => array(
 			'exclude' => 1,
 			'label'   => 'LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:tx_html5videoplayer_domain_model_video.controlsvideo',
@@ -389,7 +397,7 @@ $tca = array(
 		),
 	),
 	'types'     => array(
-		'0' => array('showitem' => '--div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:video,title;;1,width, height,posterimage, mp4source, webmsource, oggsource, youtube,--div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:configurations, downloadlinks, supportvideojs, preloadvideo, autoplayvideo, loopvideo, controlsvideo, --div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:description, description;;;richtext:rte_transform[flag=rte_enabled|mode=ts_css]')
+		'0' => array('showitem' => '--div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:video,title;;1,width, height,posterimage, mp4source, webmsource, oggsource, youtube,--div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:configurations, downloadlinks, supportvideojs, preloadvideo, autoplayvideo, loopvideo, video_starttime, controlsvideo, --div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:description, description;;;richtext:rte_transform[flag=rte_enabled|mode=ts_css]')
 
 	),
 	'palettes'  => array(
@@ -399,7 +407,7 @@ $tca = array(
 );
 
 if (\HVP\Html5videoplayer\Div::featureEnable('vimeo')) {
-	$tca['types']['0'] = array('showitem' => '--div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:video,title;;1,width, height,posterimage, mp4source, webmsource, oggsource, youtube,vimeo,--div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:configurations, downloadlinks, supportvideojs, preloadvideo, autoplayvideo, loopvideo, controlsvideo, --div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:description, description;;;richtext:rte_transform[flag=rte_enabled|mode=ts_css]');
+	$tca['types']['0'] = array('showitem' => '--div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:video,title;;1,width, height,posterimage, mp4source, webmsource, oggsource, youtube,vimeo,--div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:configurations, downloadlinks, supportvideojs, preloadvideo, autoplayvideo, loopvideo, video_starttime, controlsvideo, --div--;LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:description, description;;;richtext:rte_transform[flag=rte_enabled|mode=ts_css]');
 }
 
 return $tca;

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -41,6 +41,7 @@
 			<label index="tx_html5videoplayer_domain_model_video.preloadvideo">Preload Video</label>
 			<label index="tx_html5videoplayer_domain_model_video.autoplayvideo">Autoplay Video</label>
             <label index="tx_html5videoplayer_domain_model_video.loopvideo">Loop Video</label>
+			<label index="tx_html5videoplayer_domain_model_video.video_starttime">Start time of video (in s)</label>
 			<label index="tx_html5videoplayer_domain_model_video.controlsvideo">Video Controls</label>
 		</languageKey>
 		<languageKey index="de" type="array">
@@ -78,6 +79,7 @@
 			<label index="tx_html5videoplayer_domain_model_video.preloadvideo">Preload Video</label>
 			<label index="tx_html5videoplayer_domain_model_video.autoplayvideo">Autoplay Video</label>
             <label index="tx_html5videoplayer_domain_model_video.loopvideo">Loop Video</label>
+            <label index="tx_html5videoplayer_domain_model_video.video_starttime">Startzeit des Videos (in s)</label>
 			<label index="tx_html5videoplayer_domain_model_video.controlsvideo">Video Controls</label>
 		</languageKey>
 	</data>

--- a/Resources/Private/Partials/Videoplayer/Entry.html
+++ b/Resources/Private/Partials/Videoplayer/Entry.html
@@ -16,7 +16,7 @@
 
 <!-- Begin VideoJS -->
 <div class="video-js-box ">
-	<video id="video_{video.uid}" class="video-js vjs-default-skin" width="{f:if(condition:'{settings.ff.videowidth} > 0', then: settings.ff.videowidth, else: video.minWidth)}" height="{f:if(condition:'{settings.ff.videoheight} > 0', then: settings.ff.videoheight, else: video.minHeight)}" preload="{video.preloadvideo}"<f:if condition="{video.autoplayvideo}"> autoplay</f:if><f:if condition="{video.loopvideo}"> loop</f:if><f:if condition="{video.posterimage}"> poster="{video.posterimage}"</f:if><f:if condition="{video.controlsvideo}"> controls</f:if> data-setup='<![CDATA[{"techOrder":["youtube","vimeo","html5","flash"], "ytcontrols": true}]]>'>
+	<video id="video_{video.uid}" class="video-js vjs-default-skin" width="{f:if(condition:'{settings.ff.videowidth} > 0', then: settings.ff.videowidth, else: video.minWidth)}" height="{f:if(condition:'{settings.ff.videoheight} > 0', then: settings.ff.videoheight, else: video.minHeight)}" preload="{video.preloadvideo}"<f:if condition="{video.autoplayvideo}"> autoplay</f:if><f:if condition="{video.loopvideo}"> loop</f:if><f:if condition="{video.posterimage}"> poster="{video.posterimage}"</f:if><f:if condition="{video.controlsvideo}"> controls</f:if> data-setup='<f:if condition="{video.videoStarttime}">{"starttime": {video.videoStarttime},</f:if><![CDATA["techOrder":["youtube","vimeo","html5","flash"], "ytcontrols": true]]>}'>
 		<f:if condition="{video.webmsource}"><source src="{video.webmsource}" type="video/webm" /></f:if>
 		<f:if condition="{video.oggsource}"><source src="{video.oggsource}" type="video/ogg" /></f:if>
 		<f:if condition="{video.mp4source}"><source src="{video.mp4source}" type="video/mp4" /></f:if>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -32,6 +32,7 @@ CREATE TABLE tx_html5videoplayer_domain_model_video (
 	autoplayvideo tinyint(3) DEFAULT '0' NOT NULL,
 	loopvideo tinyint(3) DEFAULT '0' NOT NULL,
 	controlsvideo tinyint(3) DEFAULT '0' NOT NULL,
+	video_starttime int(11) DEFAULT '0' NOT NULL,
 
 	PRIMARY KEY (uid),
 	KEY parent (pid)


### PR DESCRIPTION
VideoJS accepts the "starttime" parameter in its initialization which
can be set to the second the video should start. This change adds
an additional field for the starttime.
