### PR TITLE
Enable translation of the Video Plugin

### DIFF
--- a/Classes/Controller/VideoplayerController.php
+++ b/Classes/Controller/VideoplayerController.php
@@ -119,6 +119,8 @@ class VideoplayerController extends ActionController
         $videos = [];
         if (!empty($videoUids) && $this->settings['videoUids']) { // TypoScript
             $videos = $this->videoRepository->findByUids(GeneralUtility::trimExplode(',', $videoUids, true));
+        } elseif (isset($contentElement['_LOCALIZED_UID'])) { // Content Element, localized
+            $videos = $this->videoRepository->findByUids($this->getVideoIdsByContentUid($contentElement['_LOCALIZED_UID']));
         } elseif (isset($contentElement['uid'])) { // Content Element
             $videos = $this->videoRepository->findByUids($this->getVideoIdsByContentUid($contentElement['uid']));
         } elseif (isset($contentElement[0]) && !is_array(isset($contentElement[0]))) { // Fluid cObject data


### PR DESCRIPTION
Hi,

I had the same issue for a client as discussed in issue #4 
Did some researching and found this solution. Have tested it only in 6.2LTS (6.2.26), not 7LTS or 8

Hope this helps and you could integrate it, would help us out enormously :)

What it does, is check if the current content element (the video player) has a translated version, if so, gets the video from that CE instead of from the untranslated parent..

Kind regards,
Bart Lammers, YouWe
