### PR TITLE
[BUGFIX] Ignore sys_language on translated video

### DIFF
--- a/Classes/Domain/Repository/VideoRepository.php
+++ b/Classes/Domain/Repository/VideoRepository.php
@@ -46,7 +46,8 @@ class VideoRepository extends Repository
     {
         $query = parent::createQuery();
         $query->getQuerySettings()
-            ->setRespectStoragePage(false);
+            ->setRespectStoragePage(false)
+            ->setRespectSysLanguage(false);
         return $query;
     }
 

--- a/Configuration/TCA/tx_html5videoplayer_domain_model_video.php
+++ b/Configuration/TCA/tx_html5videoplayer_domain_model_video.php
@@ -12,6 +12,7 @@ $tca = [
         'crdate'                   => 'crdate',
         'cruser_id'                => 'cruser_id',
         'languageField'            => 'sys_language_uid',
+        'transOrigPointerTable'    => '',
         'transOrigPointerField'    => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'sortby'                   => 'sorting',


### PR DESCRIPTION
Very sorry, there appears to be a bug in 6.2 that needs this enabled and I forgot I had it altered when committing.
