### PR TITLE
Remove invalid Argument class

### DIFF
--- a/Resources/Private/Templates/Videoplayer/Overview.html
+++ b/Resources/Private/Templates/Videoplayer/Overview.html
@@ -3,7 +3,7 @@
 
 <f:section name="main">
 	<div class="overview">
-		<f:flashMessages class="flashmessage" />
+		<f:flashMessages />
 		<f:render partial="Videoplayer/List" arguments="{videos: videos, size: 100}" />
 	</div>
 </f:section>


### PR DESCRIPTION
The Argument "class" is not valid for the flashmessages-Viewhelper.
Thus an error occurs:
Undeclared arguments passed to ViewHelper TYPO3\\CMS\\Fluid\\ViewHelpers\\FlashMessagesViewHelper: class. Valid arguments are: queueIdentifier