### PR TITLE
fixes tca - was causing fatal error in backend video content edit form

### DIFF
--- a/Configuration/TCA/tx_html5videoplayer_video_content.php
+++ b/Configuration/TCA/tx_html5videoplayer_video_content.php
@@ -5,7 +5,7 @@ if (!defined('TYPO3_MODE')) {
 }
 return [
     'ctrl'      => [
-        // 'label'     => 'Video/Content Relation',
+        'label'     => 'Video/Content Relation',
         'title'     => 'LLL:EXT:html5videoplayer/Resources/Private/Language/locallang.xml:video_relation',
         'hideTable' => true,
         'sortby'    => 'sorting',


### PR DESCRIPTION
Key `'label'` in TCA's `'ctrl'` section is required:
https://docs.typo3.org/m/typo3/reference-tca/8.7/en-us/Ctrl/Index.html

Now this extension causes fatal error in backend:
`Fatal error: Uncaught UnexpectedValueException: TCA of table tx_html5videoplayer_video_content misses required ['ctrl']['label'] definition. `
so this needs to be fixed to make it usable out-of-the-box again.