### PR TITLE
Cope with empty spaces in path or filename

### DIFF
--- a/Classes/Domain/Model/Video.php
+++ b/Classes/Domain/Model/Video.php
@@ -521,9 +521,9 @@ class Video extends AbstractEntity
             ));
         }
 
-        if (is_file(Environment::getPublicPath() . '/' . $media)) {
+        if (is_file(Environment::getPublicPath() . '/' . rawurldecode($media))) {
             $filePathSanitizer = GeneralUtility::makeInstance(FilePathSanitizer::class);
-            return $filePathSanitizer->sanitize($media);
+            return $filePathSanitizer->sanitize(rawurldecode($media));
         }
 
         $mediaWizard = null;


### PR DESCRIPTION
If there are files or folders with empty spaces in fileadmin (possible by uploading via ftp), and they are used i.e. as Poster Image, then the exception
"Could not fetch the URL in the right way" is thrown. 
This pull request handles such files.