### PR TITLE
[TASK] Provide extensionkey in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
   },
   "extra": {
     "typo3/cms": {
+      "extension-key": "html5videoplayer",
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
       "web-dir": ".Build/Web",
       "Package": {


### PR DESCRIPTION
Avoid this warning:

The TYPO3 extension package "lochmueller/html5videoplayer", does not define an extension key in its composer.json. Please report this to the author of this package. Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
