### PR TITLE
[TASK] remove transOrigPointerField to avoid warning in installtool

### DIFF
--- a/Configuration/TCA/tx_html5videoplayer_domain_model_video.php
+++ b/Configuration/TCA/tx_html5videoplayer_domain_model_video.php
@@ -13,7 +13,6 @@ $tca = [
         'cruser_id' => 'cruser_id',
         'languageField' => 'sys_language_uid',
         'transOrigPointerTable' => '',
-        'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'sortby' => 'sorting',
         'delete' => 'deleted',


### PR DESCRIPTION
The 'tx_html5videoplayer_domain_model_video' TCA tables transOrigPointerField 'l10n_parent' is defined as excluded field which is no longer needed and should therefore be removed.