### PR TITLE
Fixes vimeo hook by lifting db restrictions

### DIFF
--- a/Classes/Hooks/VimeoProcessDatamap.php
+++ b/Classes/Hooks/VimeoProcessDatamap.php
@@ -35,6 +35,7 @@ class VimeoProcessDatamap
             if ($status === 'update') {
                 $table = 'tx_html5videoplayer_domain_model_video';
                 $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+                $queryBuilder->getRestrictions()->removeAll();
                 $res = $queryBuilder->select('*')
                     ->from($table, 'video')
                     ->where($queryBuilder->expr()->eq('video.uid',


### PR DESCRIPTION
A hidden file would not be found with the `DefaultRestrictionsContainer` in place and thus cannot be unhidden.